### PR TITLE
Fix TShape

### DIFF
--- a/rnnt_loss-inl.h
+++ b/rnnt_loss-inl.h
@@ -227,7 +227,7 @@ class RNNTLossProp : public OperatorProperty {
     CHECK_EQ(llshape[0], lshape[0])
         << "The batch size for the labels and label lengths must be the same.";
 
-    TShape oshape(1);
+    TShape oshape(1; 1);
     oshape[0] = dshape[0];  // batch size
     out_shape->clear();
     out_shape->push_back(oshape);


### PR DESCRIPTION
Fix MXNet 1.5.x build error
`error: no matching function for call to ‘mxnet::TShape::TShape(int)’`
Same as https://github.com/apache/incubator-mxnet/pull/15827/files