### PR TITLE
Fix __shfl_down error

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ class RNNTLoss(Loss):
 From the repo test with:
 
 ```bash
-python test/test.py 10 300 100 50 --mx
+python test/test.py --mx
 ```
 
 ## Reference

--- a/rnnt_include/detail/reduce.h
+++ b/rnnt_include/detail/reduce.h
@@ -30,7 +30,7 @@ struct CTAReduce {
 
         T shuff;
         for (int offset = warp_size / 2; offset > 0; offset /= 2) {
-            shuff = __shfl_down(x, offset);
+            shuff = __shfl_down_sync(0xFFFFFFFF, x, offset);
             if (tid + offset < count && tid < offset)
                 x = g(x, shuff);
         }


### PR DESCRIPTION
MXNet build error with cuda10.1 (identifier "__shfl_down" is undefined). 
Same fix like https://github.com/SeanNaren/deepspeech.pytorch/issues/397#issuecomment-470784387

Tested with MXNet 1.5.0, cuda 9.2 and 10.1